### PR TITLE
Tidy up all instances of try: except:

### DIFF
--- a/PuxBulletf.py
+++ b/PuxBulletf.py
@@ -74,8 +74,11 @@ class PuxBullet:
 			try:
 				r = requests.request(method, url, data=postdata, params=params, headers=headers, files=files, auth=HTTPBasicAuth(self.ACCESS_TOKEN, ""),timeout=99)
 				status_codes.append(r.status_code)
-			except:
+			except requests.exceptions.ConnectTimeout as ex:
+				print('PushBullet request timedout.')
 				status_codes.append(1)
+			except Exception as ex:
+				BFun.ezLog('Error when making pushbullet request:',ex)
 			if status_codes[-1] == 403:
 				self.getAccessToken()
 			if len(status_codes) > 100:
@@ -111,8 +114,8 @@ class PuxBullet:
 				# use try except since we don't want messages going to None if we can't get the iden
 				try:
 					self.browserIdens.append(device['iden'])
-				except:
-					pass
+				except Exception as ex:
+					BFun.ezLog('Error when getting browser idens in PuxBulletf. Search for 1751686',ex)
 	
 	def createThisDevice(self):
 		devices = self.getDevices()
@@ -196,6 +199,6 @@ class PuxBullet:
 						if pushIden:
 							#self.dismissPush(pushIden)
 							self.deletePush(pushIden)
-				except:
-					print('Message broke command finder: '+pBody)
+				except Exception as ex:
+					BFun.ezLog('Message (%s) broke command finder in PuxBulletf. Search for 2832516'%pBody,ex)
 		return commandList

--- a/PuxFunc.py
+++ b/PuxFunc.py
@@ -1,6 +1,0 @@
-import PuxGlobal
-import BFun
-from PuxShowf import PuxShow
-from PuxBulletf import PuxBullet
-
-

--- a/PuxThreads.py
+++ b/PuxThreads.py
@@ -140,7 +140,8 @@ class PushBulletT(threading.Thread):
 				arguments = aDict['arguments']
 				try:
 					command = arguments.pop(0)
-				except:
+				except IndexError as ex:
+					print('Argument list was empty')
 					command = ''
 				commandLower = command.lower()
 				if commandLower == 'speak':
@@ -230,11 +231,12 @@ class TorrentT(threading.Thread):
 						print('Checking torrents of '+show.SHOW_NAME)
 						try:
 							show.checkTorrents()
-						except:
-							print('Something went wrong. Probably Transmission down?')
+						except Exception as ex:
+							BFun.ezLog('Error when calling show.checkTorrents() in PuxThreads.TorrentT.run()',ex)
+							print('Error when calling show.checkTorrents() in PuxThreads.TorrentT.run()')
 							self.counters['add'] = self.counterFreq['add'] - 1
 				self.advanceCounters()
-		except:
+		except Exception as ex:
 			BFun.ezLog('Torrent thread broke',ex)
 		# If it gets to here, it means we're trying to join.
 		for show in self.showList:


### PR DESCRIPTION
According to
https://realpython.com/blog/python/the-most-diabolical-python-antipattern/
, having try: except: is bad and if you must have it, log the full stack
trace. In this branch, we log the stack trace for every "except:" block
so we can make it handle specific exceptions. If we know what exceptions
we are trying to catch, we'll specifically catch those and no need to
log.

Also fixed a non-increasing counter in BFun.webRead()
